### PR TITLE
Add 'permission_function' attribute to view

### DIFF
--- a/permissions/registry.py
+++ b/permissions/registry.py
@@ -271,6 +271,9 @@ class PermissionsRegistry:
             elif not callable(view):
                 raise PermissionsError('Bad call to permissions decorator')
 
+            # add an attribute to the view to facilitate unit testing
+            view.permission_function = perm_func
+
             # When a permission is applied to a class, which is presumed
             # to be a class-based view, instead apply the permission to
             # the class's dispatch() method. This will effectively

--- a/permissions/tests/test_registry.py
+++ b/permissions/tests/test_registry.py
@@ -186,3 +186,14 @@ class TestRegistry(TestCase):
         self.assertFalse(handler.called)
         view(request, 1)
         self.assertTrue(handler.called)
+
+    def test_permission_function_attribute_is_added_to_view(self):
+        @self.registry.register
+        def perm(user):
+            pass
+
+        @self.registry.require("perm")
+        def view(request):
+            pass
+
+        self.assertEqual(view.permission_function, perm)


### PR DESCRIPTION
This allows you to perform simpler unit testing on views decorated by permissions functions:

    self.assertEqual(some_view.permission_function, can_do_something)

This is the cheapest way I can think of doing it. I'm very open to other ideas on how to better facilitate testing.