### PR TITLE
Add a `permission_of` mapping to the registry

### DIFF
--- a/permissions/registry.py
+++ b/permissions/registry.py
@@ -122,6 +122,11 @@ class PermissionsRegistry:
                  unauthenticated_handler=None, request_types=None):
         self._registry = dict()
 
+        # this allows us to inspect the registry and determine which view has
+        # which permission function applied. It is a mapping of a view to a
+        # permission function
+        self.permission_of = dict()
+
         settings = DEFAULT_SETTINGS.copy()
         if hasattr(django.conf.settings, 'PERMISSIONS'):
             settings.update(django.conf.settings.PERMISSIONS)
@@ -289,6 +294,7 @@ class PermissionsRegistry:
             # below are reached, we decorate MyView.dispatch() and
             # then return MyView.
             if isinstance(view, type):
+                self.permission_of[view] = perm_func
                 view.dispatch = view_decorator(view.dispatch, field)
                 return view
 
@@ -379,6 +385,7 @@ class PermissionsRegistry:
                         'The "{0}" permission is required to access this resource'
                         .format(perm_name))
 
+            self.permission_of[wrapper] = perm_func
             return wrapper
         return view_decorator
 

--- a/permissions/tests/test_registry.py
+++ b/permissions/tests/test_registry.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import PermissionDenied
+from django.views.generic import View
 
 from permissions import PermissionsRegistry
 from permissions.exc import NoSuchPermissionError, PermissionsError
@@ -186,3 +187,37 @@ class TestRegistry(TestCase):
         self.assertFalse(handler.called)
         view(request, 1)
         self.assertTrue(handler.called)
+
+    def test_view_to_permission_mapping(self):
+        """
+        When a permission is applied to a view, the registry should save the
+        (view, permission_function) pair as a map. This makes it easier to
+        unit test the view, so you can ensure it was decorated with the right
+        permission function.
+        """
+
+        @self.registry.register
+        def perm(user):
+            pass
+
+        @self.registry.require("perm")
+        def view(request):
+            pass
+
+        self.assertEqual(self.registry.permission_of[view], perm)
+
+        # try the same thing with a CBV
+        @self.registry.require("perm")
+        class AView(View):
+            def get(self, request):
+                pass
+
+        self.assertEqual(self.registry.permission_of[AView], perm)
+
+        # same thing with the permission on a CBV method
+        class AnotherView(View):
+            @self.registry.require("perm")
+            def get(self, request):
+                pass
+
+        self.assertEqual(self.registry.permission_of[AnotherView.get], perm)


### PR DESCRIPTION
This maps the view to the permission function, so ensuring the right permission is applied to the view can be done more easily in unit tests.

The is an alternative implementation of #1.